### PR TITLE
Fixing composer package/module name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
-  "name": "graphiques-digitale/silverstripe-seo-authorship",
+  "name": "graphiques-digitale/silverstripe-seo-google-plus-authorship",
+  "replace": { "graphiques-digitale/silverstripe-seo-authorship": "*" },
   "description": "Authorship module for the SilverStripe framework",
   "type": "silverstripe-module",
   "homepage": "https://github.com/Graphiques-Digitale/silverstripe-seo-icons",


### PR DESCRIPTION
Keeping composer package/module name consistent with the other modules. Replace should do the job allow old composer.json files in the project still to use the old named package.
